### PR TITLE
Remove leading / which is creating a new blank named folder in s3

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ const plugin = (aws, opts) => {
 
     try {
       let uploadPath = file.path.replace(file.base, options.uploadPath || '')
-        .replace(new RegExp('\\\\', 'g'), '/');
+        .replace(new RegExp('\\\\', 'g'), '/').replace(new RegExp('^/'),"");
 
       // Explicitly set headers
       // Else default to public access for all files


### PR DESCRIPTION
My files are
`dist/index.html`

and my gulp file 
```javascript
    gulp.task('s3upload',function(){
        gulp.src([ 'dist/*'] )
         .pipe( s3( s3Credentials,{ concurrency: 5 }  ) );
    });
```
I had ran this successfully before but today it ended up creating an S3 folder with no name so the paths were `s3bucket//index.html`

This fixed it