### PR TITLE
Remove extraneous leading forward slash on uploaded files

### DIFF
--- a/src/clean.ts
+++ b/src/clean.ts
@@ -6,6 +6,8 @@ import * as log from 'fancy-log';
 import { S3 } from 'aws-sdk'
 import { chunk } from 'lodash';
 
+import { getUploadPath } from "./utils";
+
 const PLUGIN_NAME = 'gulp-s3-publish/clean';
 
 export interface CleanOpts {
@@ -40,10 +42,7 @@ export function clean(client: S3, userOptions: CleanOpts) {
       this.emit('error', new PluginError(PLUGIN_NAME, 'Streams not supported!'));
     }
 
-    const uploadPath = file.path
-      .replace(file.base, options.uploadPath || '')
-      .replace(new RegExp('\\\\', 'g'), '/');
-  
+    const uploadPath = getUploadPath(file, options.uploadPath || '');
     files.push(uploadPath);
     return callback();
   }

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -6,6 +6,8 @@ import * as log from 'fancy-log';
 import { S3 } from 'aws-sdk'
 import { TransformFunction } from 'through2';
 
+import { getUploadPath } from "./utils";
+
 const defaultMimeType = 'text/plain'; // eslint-disable-line
 const PLUGIN_NAME = 'gulp-s3-publish/upload';
 
@@ -36,10 +38,7 @@ export function upload(client: S3, userOptions: UploadOpts) {
       return callback(new PluginError(PLUGIN_NAME, 'Streams not supported!'));
     }
 
-    const uploadPath = file.path
-      .replace(file.base, options.uploadPath || '')
-      .replace(new RegExp('\\\\', 'g'), '/');
-
+    const uploadPath = getUploadPath(file, options.uploadPath || '');
     const uploadParams: Partial<S3.Types.PutObjectRequest> = options.putObjectParams;
     uploadParams.Bucket = options.bucket;
     uploadParams.ContentType = getType(file.path) || defaultMimeType;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,22 @@
+const DOUBLE_BACKSLASH_REGEX = new RegExp('\\\\', 'g');
+const LEADING_FORWARD_SLASH_REGEX = new RegExp(/^\/+/);
+
+export function getUploadPath(file: { path: string; base: string }, uploadPath: string): string {
+  let relativeFilename = file.path
+    .replace(file.base, '')
+    .replace(DOUBLE_BACKSLASH_REGEX, '/');
+
+  // Remove any remaining, leading forward slashes, which could throw off the
+  // upload path by creating unintended intermediary directories.
+  if (relativeFilename.startsWith('/')) {
+    relativeFilename = relativeFilename.replace(LEADING_FORWARD_SLASH_REGEX, '');
+  }
+
+  // Apply upload path
+  if (!uploadPath) {
+    // No separators necessary
+    return relativeFilename;
+  }
+
+  return `${uploadPath}/${relativeFilename}`;
+}


### PR DESCRIPTION
There's a separate PR here (#8) which does the same thing, but looks to be based off an older version of the repo.

I found when I was using this locally that if I wanted to upload files to the root of the S3 bucket, I wasn't able to -- it would always upload it to a directory that existed in the root, named `/`. So the file **foo.txt** that I wanted in the root was being uploaded inside of directory **/**.

This seems to be the case when you have an empty `uploadPath`. The filepath (pre-upload path) still has the leading `/` from lopping off the base, which is useful for joining the `uploadPath` to it and producing a valid directory structure. But when there is no `uploadPath`, it still keeps the separator, which throws off the process.